### PR TITLE
Disable Client Certificate Authentication

### DIFF
--- a/defaults/default-ssl.conf
+++ b/defaults/default-ssl.conf
@@ -69,8 +69,8 @@
 		#   none, optional, require and optional_no_ca.  Depth is a
 		#   number which specifies how deeply to verify the certificate
 		#   issuer chain before deciding the certificate is not valid.
-		SSLVerifyClient optional_no_ca
-		SSLVerifyDepth  10
+		#SSLVerifyClient optional_no_ca
+		#SSLVerifyDepth  10
 
 		#   SSL Engine Options:
 		#   Set various options for the SSL engine.


### PR DESCRIPTION
These settings that I've commented out, while optional, cause Safari to freak out.  I have tested this locally, and commenting out SSLVerifyClient and SSLVerifyDepth fixes the issue.