### PR TITLE
Fix issue where group does not exist

### DIFF
--- a/init/40_firstrun.sh
+++ b/init/40_firstrun.sh
@@ -188,6 +188,13 @@ ln -s /config/mysql /var/lib/mysql
 PUID=${PUID:-99}
 PGID=${PGID:-100}
 usermod -o -u $PUID nobody
+
+# Check if the group with GUID passed as environment variable exists and create it if not.
+if ! getent group "$PGID" >/dev/null; then
+  groupadd -g "$PGID" env-provided-group
+  echo "Group with id: $PGID did not already exist, so we created it."
+fi
+
 usermod -g $PGID nobody
 usermod -d /config nobody
 


### PR DESCRIPTION
On my Ubuntu Focal host, my user has the primary group id 1000. Since all the directories used in the mounts are created by this user, I pass it in with `docker run ... -e PGID="1000" \ ...`.
However, the image doesn't have a group with id 1000 so we see the following in the log at startup:
```
Creating symbolink links
usermod: group '1000' does not exist
```
This change creates a new group in the container if one is required.