### PR TITLE
Redo PR

### DIFF
--- a/defaults/default-ssl.conf
+++ b/defaults/default-ssl.conf
@@ -69,8 +69,8 @@
 		#   none, optional, require and optional_no_ca.  Depth is a
 		#   number which specifies how deeply to verify the certificate
 		#   issuer chain before deciding the certificate is not valid.
-		SSLVerifyClient optional_no_ca
-		SSLVerifyDepth  10
+		#SSLVerifyClient optional_no_ca
+		#SSLVerifyDepth  10
 
 		#   SSL Engine Options:
 		#   Set various options for the SSL engine.


### PR DESCRIPTION
#14 previously addressed a problem in Safari where it asks for client certificates when browsing ZM.  493fe9f inadvertently undid #14's changes. This PR is to re-do those changes, which is to disable client certificate authentication in Apache entirely.